### PR TITLE
Add option to adjust visibility of comments and special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ If you want to use your default terminal background, put this **before `colorsch
 let g:neodark#terminal_transparent = 1 " default: 0
 ```
 
+If you want to adjust the visibility of comments, listchars, and specialkey, put this **before `colorscheme neodark`**
+```vim
+let g:neodark#visibility = 'low' " options: 'low'|'high',  default: ''
+```
+
 [Airline](https://github.com/vim-airline/vim-airline) and [lightline](https://github.com/itchyny/lightline.vim) themes are also included. For lightline,
 
 ```vim

--- a/colors/neodark.vim
+++ b/colors/neodark.vim
@@ -10,6 +10,10 @@ if !exists('g:neodark#italics')
   let g:neodark#italics = 0
 endif
 
+if !exists('g:neodark#visibility')
+  let g:neodark#visibility = ''
+endif
+
 if !exists('g:neodark#use_custom_terminal_theme')
   let g:neodark#use_custom_terminal_theme = 0
 endif
@@ -148,7 +152,6 @@ call s:hi('LineNr',                    s:base3,      '',         '')
 call s:hi('MatchParen',                s:light_blue, s:base1,    'underline,bold')
 call s:hi('ModeMsg',                   s:green,      '',         '')
 call s:hi('MoreMsg',                   s:green,      '',         '')
-call s:hi('NonText',                   s:base4,      '',         'none')
 call s:hi('Normal',                    s:base5,      s:base1,    'none')
 call s:hi('Pmenu',                     s:base5,      s:base3,    '')
 call s:hi('PmenuSbar',                 '',           s:base2,    '')
@@ -157,7 +160,6 @@ call s:hi('PmenuThumb',                '',           s:base4,    '')
 call s:hi('Question',                  s:blue,       '',         'none')
 call s:hi('Search',                    s:base1,      s:beige,    '')
 call s:hi('SignColumn',                s:base5,      s:base1,    '')
-call s:hi('SpecialKey',                s:base4,      '',         '')
 call s:hi('SpellBad',                  s:red,        s:base1,    'underline')
 call s:hi('SpellCap',                  s:brown,      s:base1,    'none')
 call s:hi('SpellRare',                 s:brown,      s:base1,    'none')
@@ -173,8 +175,22 @@ call s:hi('Visual',                    s:base5,      s:base3,    '')
 call s:hi('WarningMsg',                s:red,        '',         '')
 call s:hi('WildMenu',                  s:base2,      s:green,	   '')
 
+" Visibility level for special characters and comments
+if g:neodark#visibility == 'low'
+  call s:hi('NonText',                   s:base1,      '',         'none')
+  call s:hi('SpecialKey',                s:base1,      '',         '')
+  call s:hi('Comment',                   s:base3,      '',         'italic')
+elseif g:neodark#visibility == 'high'
+  call s:hi('NonText',                   s:base4,      '',         'none')
+  call s:hi('SpecialKey',                s:base4,      '',         '')
+  call s:hi('Comment',                   s:base4,      '',         'italic')
+else
+  call s:hi('NonText',                   s:base2,      '',         'none')
+  call s:hi('SpecialKey',                s:base3,      '',         '')
+  call s:hi('Comment',                   s:base3,      '',         'italic')
+endif
+
 " Standard Syntax
-call s:hi('Comment',                   s:base4,      '',         'italic')
 call s:hi('Constant',                  s:red,        '',         '')
 call s:hi('String',                    s:orange,     '',         '')
 call s:hi('Character',                 s:orange,     '',         '')


### PR DESCRIPTION
Adds new option `g:neodark#visibility` to change prominence of comments and special characters. This is roughly equivalent to the `g:solarized_visibility` option in Solarized.

Note: I wanted to try and keep the previous settings at the default, but I think the config makes more sense with `high|default|low` options rather than a `default|low|lowest`. The original neodark values are under the `high` setting.

Example:

![visibility_options](https://cloud.githubusercontent.com/assets/34955/23608648/44641482-0262-11e7-9b29-fa68aadc2d69.png)
