### PR TITLE
Option `g:neodark#solid_vertsplit` to show vertical splits as solid bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ If you want to use your default terminal background, put this **before `colorsch
 let g:neodark#terminal_transparent = 1 " default: 0
 ```
 
+If you want solid vertical split matching the statusline, put this **before `colorscheme neodark`**
+```vim
+let g:neodark#solid_vertsplit = 1 " default: 0
+```
+
 [Airline](https://github.com/vim-airline/vim-airline) and [lightline](https://github.com/itchyny/lightline.vim) themes are also included. For lightline,
 
 ```vim

--- a/colors/neodark.vim
+++ b/colors/neodark.vim
@@ -26,6 +26,10 @@ if !exists('g:neodark#terminal_transparent')
   let g:neodark#terminal_transparent = 0
 endif
 
+if !exists('g:neodark#solid_vertsplit')
+  let g:neodark#solid_vertsplit = 0
+endif
+
 if g:neodark#background == 'black'
   let s:base1 = ['#191919', 236]
   let s:base2 = ['#252525', 237]
@@ -168,10 +172,16 @@ call s:hi('TabLine',                   s:base4,      s:base2,    'none')
 call s:hi('TabLineFill',               s:base4,      s:base2,    'none')
 call s:hi('TabLineSel',                s:yellow,     s:base3,    'none')
 call s:hi('Title',                     s:orange,     '',         'none')
-call s:hi('VertSplit',                 s:base4,      s:base1,    'none')
 call s:hi('Visual',                    s:base5,      s:base3,    '')
 call s:hi('WarningMsg',                s:red,        '',         '')
 call s:hi('WildMenu',                  s:base2,      s:green,	   '')
+
+" Solid bar for vertical split
+if g:neodark#solid_vertsplit == 1
+  call s:hi('VertSplit',                 s:base2,      s:base2,    'none')
+else
+  call s:hi('VertSplit',                 s:base4,      s:base1,    'none')
+endif
 
 " Standard Syntax
 call s:hi('Comment',                   s:base4,      '',         'italic')


### PR DESCRIPTION
As discussed in https://github.com/KeitaNakamura/neodark.vim/pull/3, this is an option to show vertical splits as a solid bar matching the status line.