### PR TITLE
Replace color decoding functions that already exist

### DIFF
--- a/colors/neodark.vim
+++ b/colors/neodark.vim
@@ -7,7 +7,7 @@ endif
 let g:colors_name = 'neodark'
 
 " Functions {{{
-function s:generate_base_colors(base1)
+function! s:generate_base_colors(base1)
   let b1 = s:RGB2HSL(s:hex2RGB(a:base1))
   let b2 = [b1[0], b1[1], b1[2]+5]
   let b3 = [b1[0], b1[1], b2[2]+10]
@@ -20,18 +20,18 @@ function s:generate_base_colors(base1)
         \ s:RGB2hex(s:HSL2RGB(b5))]
 endfunction
 
-function s:hex2RGB(hex)
+function! s:hex2RGB(hex)
   let R = printf("%d", "0x".a:hex[1:2])
   let G = printf("%d", "0x".a:hex[3:4])
   let B = printf("%d", "0x".a:hex[5:6])
   return [R,G,B]
 endfunction
 
-function s:RGB2hex(RGB)
+function! s:RGB2hex(RGB)
   return printf("#%x%x%x", a:RGB[0], a:RGB[1], a:RGB[2])
 endfunction
 
-function s:RGB2HSL(RGB)
+function! s:RGB2HSL(RGB)
   let R = a:RGB[0]
   let G = a:RGB[1]
   let B = a:RGB[2]
@@ -65,7 +65,7 @@ function s:RGB2HSL(RGB)
   return [H,S,L]
 endfunction
 
-function s:HSL2RGB(HSL)
+function! s:HSL2RGB(HSL)
   let H = a:HSL[0]
   let S = a:HSL[1]
   let L = a:HSL[2]


### PR DESCRIPTION
After updating to the latest `neodark.vim` using NVIM 0.1.7 I receive the following errors:
```Error detected while processing /Users/twexler/.config/nvim/plugged/neodark.vim/colors/neodark.vim:
line   21:
E122: Function <SNR>15_generate_base_colors already exists, add ! to replace it
line   29:
E122: Function <SNR>15_hex2RGB already exists, add ! to replace it
line   35:
E122: Function <SNR>15_RGB2hex already exists, add ! to replace it
line   71:
E122: Function <SNR>15_RGB2HSL already exists, add ! to replace it
line  114:
E122: Function <SNR>15_HSL2RGB already exists, add ! to replace it
line   21:
E122: Function <SNR>15_generate_base_colors already exists, add ! to replace it
line   29:
E122: Function <SNR>15_hex2RGB already exists, add ! to replace it
line   35:
E122: Function <SNR>15_RGB2hex already exists, add ! to replace it
line   71:
E122: Function <SNR>15_RGB2HSL already exists, add ! to replace it
line  114:
E122: Function <SNR>15_HSL2RGB already exists, add ! to replace it
```

This PR resolves that issue.