### PR TITLE
Add terminal colors for vim 8 and neovim

### DIFF
--- a/colors/neodark.vim
+++ b/colors/neodark.vim
@@ -204,6 +204,30 @@ if g:neodark#terminal_transparent == 1
   let s:base1[1] = 'none' " This doesn't work well for airline
 end
 
+" neovim terminal colors
+if has('nvim')
+  let g:terminal_color_0  = s:base1[0]
+  let g:terminal_color_1  = s:red[0]
+  let g:terminal_color_2  = s:green[0]
+  let g:terminal_color_3  = s:yellow[0]
+  let g:terminal_color_4  = s:blue[0]
+  let g:terminal_color_5  = s:purple[0]
+  let g:terminal_color_6  = s:orange[0]
+  let g:terminal_color_7  = s:base4[0]
+  let g:terminal_color_8  = s:base2[0]
+  let g:terminal_color_9  = s:pink[0]
+  let g:terminal_color_10 = s:teal[0]
+  let g:terminal_color_11 = s:beige[0]
+  let g:terminal_color_12 = s:light_blue[0]
+  let g:terminal_color_13 = s:base3[0]
+  let g:terminal_color_14 = s:brown[0]
+  let g:terminal_color_15 = s:base5[0]
+endif
+
+" vim terminal colors
+let g:terminal_ansi_colors = [s:base1[0], s:red[0], s:green[0], s:yellow[0],
+      \ s:blue[0], s:purple[0], s:orange[0], s:base4[0], s:base2[0], s:pink[0],
+      \ s:teal[0], s:beige[0], s:light_blue[0], s:base3[0], s:brown[0], s:base5[0]]
 
 function! s:hi(group, fg, bg, attr)
   let l:attr = a:attr


### PR DESCRIPTION
Neovim and Vim 8 has support for embedded terminal, this pr is for fixing the terminal colors

before:
![image](https://user-images.githubusercontent.com/281076/40572944-cdc59ba0-60ea-11e8-9a82-1ff168d0e950.png)

after:
![image](https://user-images.githubusercontent.com/281076/40572954-f6c00572-60ea-11e8-8dd3-b1280831d6eb.png)

