### PR TITLE
Add error and warning color for lightline

### DIFF
--- a/autoload/lightline/colorscheme/neodark.vim
+++ b/autoload/lightline/colorscheme/neodark.vim
@@ -27,6 +27,10 @@ let s:p.normal.left = [
 let s:p.normal.right = [
             \ [s:base4[0], s:base1[0], s:base4[1], s:base1[1], 'inverse'],
             \ [s:base4[0], s:base3[0], s:base4[1], s:base3[1]]]
+let s:p.normal.error = [
+            \ [ s:base2[0], s:red[0], s:base2[1], s:red[1]]]
+let s:p.normal.warning = [
+            \ [ s:base2[0], s:yellow[0], s:base2[1], s:yellow[1]]]
 
 let s:p.inactive.middle = [
 			\ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]


### PR DESCRIPTION
Thank you for developing beautiful color scheme.

I added error and warning color for lightline.
This is useful to display the results of linting.

Sample: (number of errors and warnings are displayed in lower right)

![スクリーンショット 2019-10-31 9 42 44](https://user-images.githubusercontent.com/17161397/67909718-91833380-fbc3-11e9-872f-3b3dde20e9ed.png)
