### PR TITLE
Remove `reverse` from lightline.vim conf

### DIFF
--- a/autoload/lightline/colorscheme/neodark.vim
+++ b/autoload/lightline/colorscheme/neodark.vim
@@ -22,10 +22,10 @@ let s:p = {
 let s:p.normal.middle = [
             \ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]
 let s:p.normal.left = [
-            \ [s:green[0], s:base1[0], s:green[1], s:base1[1], 'inverse'],
+            \ [s:base1[0], s:green[0], s:base1[1], s:green[1]],
             \ [s:base5[0], s:base3[0], s:base5[1], s:base3[1]]]
 let s:p.normal.right = [
-            \ [s:base4[0], s:base1[0], s:base4[1], s:base1[1], 'inverse'],
+            \ [s:base1[0], s:base4[0], s:base1[1], s:base4[1]],
             \ [s:base4[0], s:base3[0], s:base4[1], s:base3[1]]]
 let s:p.normal.error = [
             \ [ s:base2[0], s:red[0], s:base2[1], s:red[1]]]
@@ -42,19 +42,19 @@ let s:p.inactive.left = [
 			\ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]
 
 let s:p.insert.left = [
-			\ [s:blue[0], s:base1[0], s:blue[1], s:base1[1], 'inverse'],
+			\ [s:base1[0], s:blue[0], s:base1[1], s:blue[1]],
 			\ s:p.normal.left[1]]
 let s:p.replace.left = [
-			\ [s:red[0], s:base1[0], s:red[1], s:base1[1], 'inverse'],
+			\ [s:base1[0], s:red[0], s:base1[1], s:red[1]],
 			\ s:p.normal.left[1]]
 let s:p.visual.left = [
-			\ [s:orange[0], s:base1[0], s:orange[1], s:base1[1], 'inverse'],
+			\ [s:base1[0], s:orange[0], s:base1[1], s:orange[1]],
 			\ s:p.normal.left[1]]
 
 let s:p.tabline.middle = [
             \ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]
 let s:p.tabline.right = [
-            \ [s:base4[0], s:base1[0], s:base4[1], s:base1[1], 'inverse'],
+            \ [s:base1[0], s:base4[0], s:base1[1], s:base4[1]],
             \ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]
 let s:p.tabline.left = [
             \ [s:base4[0], s:base2[0], s:base4[1], s:base2[1]]]


### PR DESCRIPTION
This change leads to fix not colorize separator of lightline.vim.

before
![screen_shot_2019-12-04T22:23:08+09:00](https://user-images.githubusercontent.com/12132068/70147220-27d8d680-16e7-11ea-89f9-e22fd15990d4.png)

after
![screen_shot_2019-12-04T22:21:50+09:00](https://user-images.githubusercontent.com/12132068/70147261-37581f80-16e7-11ea-84d2-705a1452e1ad.png)