### PR TITLE
Make a plugin autoloadize

### DIFF
--- a/autoload/neodark.vim
+++ b/autoload/neodark.vim
@@ -1,8 +1,3 @@
-if exists("g:loaded_neodark")
-  finish
-endif
-let g:loaded_neodark = 1
-
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -14,7 +9,6 @@ function neodark#get_color(hlgroup, fg_or_bg)
   endif
   return [l:gui, l:cterm]
 endfunction
-
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This is for a little bit startup time improvement by autoloading. No always need to define the function at the time of startup because maybe the function isn't called at that time. And the function name is already an autoloadable form.